### PR TITLE
feat(stdin): call lock only once, by explicitly doing so

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,10 @@ fn main() {
     let mut values = Vec::new();
     let mut state = "out";
 
-    for byte in io::stdin().bytes() {
+    let stdin = io::stdin();
+    let handle = stdin.lock();
+
+    for byte in handle.bytes() {
         let c = byte.unwrap() as char;
 
         if c == '\n' {


### PR DESCRIPTION
the code was calling lock on every byte! by explicitly calling lock we can call it only one time, the docs show this here: https://doc.rust-lang.org/stable/std/io/struct.Stdin.html#examples :) 